### PR TITLE
Add lazy Gradle configuration to cofnigure tasks only when necessary

### DIFF
--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPluginTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPluginTest.kt
@@ -2,6 +2,7 @@ package com.jraska.module.graph.assertion
 
 import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
 import org.junit.Test
@@ -17,11 +18,14 @@ class ModuleGraphAssertionsPluginTest {
 
   @Test
   fun testAddsOnlyOneTaskWhenApplied() {
+    val checkDependsOnSize = project.tasks.findByName(CHECK_TASK_NAME)!!.dependsOn.size
+
     project.plugins.apply(ModuleGraphAssertionsPlugin::class.java)
     project.evaluate()
 
     assert(project.tasks.findByName(Api.Tasks.ASSERT_ALL) != null)
     assert(project.tasks.findByName(Api.Tasks.ASSERT_ALL)!!.dependsOn.isEmpty())
+    assert(project.tasks.findByName(CHECK_TASK_NAME)!!.dependsOn.size == checkDependsOnSize + 1)
   }
 
   @Test


### PR DESCRIPTION
Resolves part 1. of #38 
https://docs.gradle.org/current/userguide/task_configuration_avoidance.html

Before: 
<img width="982" alt="Screenshot 2020-03-20 at 00 27 58" src="https://user-images.githubusercontent.com/6277721/77123964-deb45480-6a41-11ea-8dc8-7e5d30278dac.png">

After - no tasks applied
<img width="994" alt="Screenshot 2020-03-20 at 00 27 41" src="https://user-images.githubusercontent.com/6277721/77123974-e3790880-6a41-11ea-8f1e-13734b623bbe.png">
