### PR TITLE
Support group matches in regex

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/Parse.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/Parse.kt
@@ -17,10 +17,6 @@ object Parse {
       throw IllegalArgumentException("Incorrect format. Expected: 'regexp${divider}regexp', found $matcherText")
     }
 
-    val regexes = matcherText.split(divider, limit = 2).map { it.toRegex() }
-    val parent = regexes[0]
-    val child = regexes[1]
-
-    return RegexpDependencyMatcher(parent, child, divider)
+    return RegexpDependencyMatcher(matcherText.toRegex(), divider)
   }
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/RegexpDependencyMatcher.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/RegexpDependencyMatcher.kt
@@ -1,17 +1,16 @@
 package com.jraska.module.graph
 
 class RegexpDependencyMatcher(
-  private val parentRegex: Regex,
-  private val childRegex: Regex,
+  private val matchingRegex: Regex,
   private val divider: String
 ) : DependencyMatcher {
 
   override fun matches(dependency: Pair<String, String>): Boolean {
-    return dependency.first.matches(parentRegex)
-      && dependency.second.matches(childRegex)
+    val dependencyToMatch = "${dependency.first}$divider${dependency.second}"
+    return matchingRegex.matches(dependencyToMatch)
   }
 
   override fun toString(): String {
-    return "$parentRegex$divider$childRegex"
+    return matchingRegex.toString()
   }
 }

--- a/plugin/src/test/kotlin/com/jraska/module/graph/ParseTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/ParseTest.kt
@@ -1,7 +1,6 @@
 package com.jraska.module.graph
 
 import org.junit.Test
-import java.lang.IllegalArgumentException
 
 class ParseTest {
   @Test
@@ -29,6 +28,29 @@ class ParseTest {
     assert(matcher.matches(":feature:aboutX" to ":lib"))
     assert(!matcher.matches(":feature:aboutX" to ":libx"))
     assert(!matcher.matches(":feature-about" to ":lib"))
+  }
+
+  @Test
+  fun groupsMatchingIsSupported() {
+    val groupingRegex = ":features:(\\S*):\\S* -> :features:\\1:\\S*"
+
+    val matcher = Parse.matcher(groupingRegex)
+
+    assert(matcher.matches(":features:X:Y" to ":features:X:Z"))
+    assert(matcher.matches(":features:data:Y" to ":features:data:Z"))
+    assert(!matcher.matches(":features:data:Y" to ":features:dat:Z"))
+  }
+
+  @Test
+  fun groupsMatchingIsSupportedForRestricted() {
+    val groupingRegex = ":features:(\\S*):(\\S*) -X> :features:\\1:\\2:\\1"
+
+    val restrictiveMatcher = Parse.restrictiveMatcher(groupingRegex)
+
+    assert(restrictiveMatcher.matches(":features:X:Y" to ":features:X:Y:X"))
+    assert(restrictiveMatcher.matches(":features:data:core" to ":features:data:core:data"))
+    assert(!restrictiveMatcher.matches(":features:X:Y" to ":features:X:Z"))
+    assert(!restrictiveMatcher.matches(":features:data:Y" to ":features:dat:Z"))
   }
 
   @Test(expected = IllegalArgumentException::class)


### PR DESCRIPTION
- Resolves #49 
- This adds support for group relations within `moduleRegex -> dependencyRegex` to allow mor flexible rules definition. Thanks @rciovati for the issue created!
- The old dependency matching strategy was matching on each member of the pair `module -> dependency` separately, but we can just match on the complete string - it brings some string allocation, but I believe it is ok.
- This is not a breaking change if the following constraint holds:
**Two separate regexes `regex1` and `regex2` matching two strings split by the ` -> ` divider separately match a subset of single regex matches, having ` -> ` as a separator: `regex1 -> regex2`** 
Therefore we might start matching more regexes, but definitely not less. Thanks to the requirement of separator it seems unlikely to me that we would introduce a breaking change to anyone.