### PR TITLE
Add longest path to statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,19 @@ moduleGraphAssert {
 - This generates a graph of dependent modules when the plugin is applied.
 - The longest path of the project is in red.
 - If you utilise [Configuration on demand](https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:configuration_on_demand) Gradle feature, please use `--no-configure-on-demand` flag along the `generateModulesGraphvizText` task.
-- Adding the parameter `modules.graph.print.statistics` causes information about the graph to be included.
 - You can set the `modules.graph.of.module` parameter if you are only interested in a sub-graph of the module graph.
 ```
-./gradlew generateModulesGraphvizText -Pmodules.graph.print.statistics=true -Pmodules.graph.of.module=:feature-one
+./gradlew generateModulesGraphvizText -Pmodules.graph.of.module=:feature-one
 ```
 - Adding the parameter `modules.graph.output.gv` saves the graphViz file to the specified path
 ```
 ./gradlew generateModulesGraphvizText -Pmodules.graph.output.gv=all_modules
+```
+
+### Graph statistics
+- Executing the task `generateModulesGraphStatistics` prints the information about the graph.
+- Statistics printed: Modules Count, [Edges Count](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#edge), [Height](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#height) and [Longest Path](https://en.wikipedia.org/wiki/Longest_path_problem) 
+- Parameter `-Pmodules.graph.of.module` is supported as well.
+```
+./gradlew generateModulesGraphStatistics -Pmodules.graph.of.module=:feature-one
 ```

--- a/plugin/src/main/kotlin/com/jraska/module/graph/DependencyGraph.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/DependencyGraph.kt
@@ -51,7 +51,8 @@ class DependencyGraph private constructor() {
     return GraphStatistics(
       modulesCount = nodes.size,
       edgesCount = edgesCount,
-      height = height
+      height = height,
+      longestPath = longestPath()
     )
   }
 

--- a/plugin/src/main/kotlin/com/jraska/module/graph/GraphStatistics.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/GraphStatistics.kt
@@ -3,5 +3,6 @@ package com.jraska.module.graph
 data class GraphStatistics(
   val modulesCount: Int,
   val edgesCount: Int,
-  val height: Int
+  val height: Int,
+  val longestPath: LongestPath
 )

--- a/plugin/src/main/kotlin/com/jraska/module/graph/LongestPath.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/LongestPath.kt
@@ -6,4 +6,6 @@ class LongestPath(
   fun pathString(): String {
     return nodeNames.joinToString(" -> ")
   }
+
+  override fun toString() = "'${pathString()}'"
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/Api.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/Api.kt
@@ -3,6 +3,7 @@ package com.jraska.module.graph.assertion
 object Api {
   object Tasks {
     const val GENERATE_GRAPHVIZ = "generateModulesGraphvizText"
+    const val GENERATE_GRAPH_STATISTICS = "generateModulesGraphStatistics"
 
     const val ASSERT_ALL = "assertModuleGraph"
     const val ASSERT_MAX_HEIGHT = "assertMaxHeight"
@@ -11,7 +12,9 @@ object Api {
   }
 
   object Parameters {
+    @Deprecated("Will be removed in version 2.0")
     const val PRINT_STATISTICS = "modules.graph.print.statistics"
+
     const val PRINT_ONLY_MODULE = "modules.graph.of.module"
     const val OUTPUT_PATH = "modules.graph.output.gv"
   }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -5,6 +5,7 @@ import com.jraska.module.graph.ModuleNameRegexMatcher
 import com.jraska.module.graph.Parse
 import com.jraska.module.graph.assertion.Api.Tasks
 import com.jraska.module.graph.assertion.tasks.AssertGraphTask
+import com.jraska.module.graph.assertion.tasks.GenerateModulesGraphStatisticsTask
 import com.jraska.module.graph.assertion.tasks.GenerateModulesGraphTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -28,6 +29,7 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
 
   internal fun addModulesAssertions(project: Project, graphRules: GraphRulesExtension) {
     project.addModuleGraphGeneration(graphRules)
+    project.addModuleGraphStatisticsGeneration(graphRules)
 
     val allAssertionsTask = project.tasks.register(Tasks.ASSERT_ALL) { it.group = VERIFICATION_GROUP }
 
@@ -51,6 +53,12 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
 
   private fun Project.addModuleGraphGeneration(graphRules: GraphRulesExtension) {
     tasks.register(Tasks.GENERATE_GRAPHVIZ, GenerateModulesGraphTask::class.java) {
+      it.configurationsToLook = graphRules.configurations
+    }
+  }
+
+  private fun Project.addModuleGraphStatisticsGeneration(graphRules: GraphRulesExtension) {
+    tasks.register(Tasks.GENERATE_GRAPH_STATISTICS, GenerateModulesGraphStatisticsTask::class.java) {
       it.configurationsToLook = graphRules.configurations
     }
   }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
@@ -1,0 +1,16 @@
+package com.jraska.module.graph.assertion.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+open class GenerateModulesGraphStatisticsTask : DefaultTask() {
+  @Input
+  lateinit var configurationsToLook: Set<String>
+
+  @TaskAction
+  fun run() {
+    val dependencyGraph = project.createDependencyGraph(configurationsToLook)
+    println(dependencyGraph.statistics())
+  }
+}

--- a/plugin/src/test/kotlin/com/jraska/module/graph/DependencyGraphTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/DependencyGraphTest.kt
@@ -87,6 +87,7 @@ class DependencyGraphTest {
     assert(dependencyGraph.findRoot().key == ":app")
     assert(dependencyGraph.heightOf(":app") == 0)
     assert(dependencyGraph.longestPath().nodeNames.equals(listOf(":app")))
+    assert(dependencyGraph.longestPath().nodeNames.equals(dependencyGraph.statistics().longestPath.nodeNames))
   }
 
   @Test(expected = IllegalArgumentException::class)
@@ -149,5 +150,12 @@ class DependencyGraphTest {
     assert(statistics.height == 5)
     assert(statistics.modulesCount == 16)
     assert(statistics.edgesCount == 45)
+    assert(statistics.longestPath.nodeNames == listOf(
+      ":feature:settings",
+      ":app",
+      ":feature:settings_entrance",
+      ":lib:dynamic-features",
+      ":core-android",
+      ":core"))
   }
 }

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPluginTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPluginTest.kt
@@ -53,4 +53,20 @@ class ModuleGraphAssertionsPluginTest {
       assert(it.configurationsToLook == Api.API_IMPLEMENTATON_CONFIGURATIONS)
     }
   }
+
+  @Test
+  fun testPrintGraphvizTextsIsAdded() {
+    project.plugins.apply(ModuleGraphAssertionsPlugin::class.java)
+    project.evaluate()
+
+    assert(project.tasks.findByName("generateModulesGraphvizText") != null)
+  }
+
+  @Test
+  fun testPrintTaskStatisticsIsAdded() {
+    project.plugins.apply(ModuleGraphAssertionsPlugin::class.java)
+    project.evaluate()
+
+    assert(project.tasks.findByName("generateModulesGraphStatistics") != null)
+  }
 }


### PR DESCRIPTION
- Add longest path to graph statistics
- modules.graph.print.statistics deprecated and separate `generateModulesGraphStatistics` created instead.
- Resolves #64 