### PR TITLE
Prepare version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ moduleGraphAssert {
 <img src="https://user-images.githubusercontent.com/6277721/142781792-752f39ce-1525-4f59-8a25-94b236476117.png" width="300" />`
   - Each module would have set `ext.moduleNameAssertAlias = "Api|Implementation|App"`
   - Module rules example for such case: `allowed = ['Implementation -> Api', 'App -> .*']`
+  - In case you want to migrate to this structure incrementally, you can set a separate module type like `ext.moduleNameAssertAlias = "NeedsMigration"` and setting `allowed = ['Implementation -> Api', 'App -> .*', 'NeedsToMigrate -> .*', '.* -> NeedsToMigrate']` and then tackling `"NeedsToMigrate"` modules one by one.
 
 ### Graphviz Graph Export
 - Visualising the graph could be useful to help find your dependency issues, therefore a helper `generateModulesGraphvizText` task is included.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,19 @@ moduleGraphAssert {
 
 <img src="https://user-images.githubusercontent.com/6277721/142781792-752f39ce-1525-4f59-8a25-94b236476117.png" width="300" />`
   - Each module would have set `ext.moduleNameAssertAlias = "Api|Implementation|App"`
-  - Module rules example for such case: `allowed = ['Implementation -> Api', 'App -> .*']`
-  - In case you want to migrate to this structure incrementally, you can set a separate module type like `ext.moduleNameAssertAlias = "NeedsMigration"` and setting `allowed = ['Implementation -> Api', 'App -> .*', 'NeedsMigration -> .*', '.* -> NeedsMigration']` and then tackling `"NeedsToMigrate"` modules one by one.
+  - Module rules example for such case: `allowed = ['Implementation -> Api', 'App -> Implementation', 'App -> Api']`
+  - In case you want to migrate to this structure incrementally, you can set a separate module type like `ext.moduleNameAssertAlias = "NeedsMigration"` and setting
+ ```
+ allowed = [
+   'Implementation -> Api', 
+   'App -> Implementation', 
+   'App -> Api', 
+   'NeedsMigration -> .*', 
+   '.* -> NeedsMigration'
+ ]
+ ```
+ 
+- `"NeedsMigration"` modules can be then tackled one by one to move them into `Implementation` or `Api` type. Example of app with this structure [can be seen here](https://github.com/jraska/github-client).
 
 ### Graphviz Graph Export
 - Visualising the graph could be useful to help find your dependency issues, therefore a helper `generateModulesGraphvizText` task is included.

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ moduleGraphAssert {
 ```
 
 ### Module name alias
-- You don't have to rely on module names and set a property `ext.moduleNameAssertAlias = "ThisWillBeAssertedOn"
+- You don't have to rely on module names and set a property `ext.moduleNameAssertAlias = "ThisWillBeAssertedOn"`
 - This can be set on any module and the `allowed`/`restricted` rules would use the alias instead of module name for asserting.
 - This is useful for example if you want to use "module types" where eaach module has a type regardless the name and you want to manage only dependnecies of different types.
 - It is recommended to use either module names or `moduleNameAssertAlias` everywhere. Mixing both is not recommended.
-- Example of module rules you could implement for flat module graph:
+- Example of module rules you could implement for a flat module graph:
 
 <img src="https://user-images.githubusercontent.com/6277721/142781792-752f39ce-1525-4f59-8a25-94b236476117.png" width="300" />`
   - Each module would have set `ext.moduleNameAssertAlias = "Api|Implementation|App"`

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ A Gradle plugin that helps keep your module graph healthy and lean.
   - Dependency, which will not match any of those rules will fail the assertion.
 - `restricted [':feature-[a-z]* -X> :forbidden-to-depend-on']` helps us to define custom rules by using `regex -X> regex` signature.
 - `maxHeight = 4` can verify that the [height of the modules tree](https://stackoverflow.com/questions/2603692/what-is-the-difference-between-tree-depth-and-height) with a root in the module will not exceed 4. Tree height is a good metric to prevent module tree degeneration into a list.
-- ~~`moduleLayers`~~ are now deprecated in favor of `allowed` syntax. 
-  - Example of migration: `moduleLayers = [":feature:\\S*", ":lib\\S*", ":core\\S*"]` -> `allowed = [":feature:\\S* -> :lib\\S*", ":feature:\\S* -> :core\\S*", :lib\\S* -> :core\\S*"]`
  
 ## Usage
 Apply the plugin to a module, which dependencies graph you want to assert.
@@ -46,11 +44,20 @@ moduleGraphAssert {
   maxHeight = 4
   allowed = [':.* -> :core', ':feature.* -> :lib.*'] // regex to match module names
   restricted = [':feature-[a-z]* -X> :forbidden-to-depend-on'] // regex to match module names
-  moduleLayers = [":feature:\\S*", ":lib\\S*", ":core\\S*"] // DEPRECATED - modules prefixed with ":feature:" -> prefix ":lib:" -> prefix :core:
-  moduleLayersExclude = [":feature-about -> :feature-legacy-about"] // DEPRECATED
   configurations = ['api', 'implementation'] // Dependency configurations to look. ['api', 'implementation'] is the default
 }
 ```
+
+### Module name alias
+- You don't have to rely on module names and set a property `ext.moduleNameAssertAlias = "ThisWillBeAssertedOn"
+- This can be set on any module and the `allowed`/`restricted` rules would use the alias instead of module name for asserting.
+- This is useful for example if you want to use "module types" where eaach module has a type regardless the name and you want to manage only dependnecies of different types.
+- It is recommended to use either module names or `moduleNameAssertAlias` everywhere. Mixing both is not recommended.
+- Example of module rules you could implement for flat module graph:
+
+<img src="https://user-images.githubusercontent.com/6277721/142781792-752f39ce-1525-4f59-8a25-94b236476117.png" width="300" />`
+  - Each module would have set `ext.moduleNameAssertAlias = "Api|Implementation|App"`
+  - Module rules example for such case: `allowed = ['Implementation -> Api', 'App -> .*']`
 
 ### Graphviz Graph Export
 - Visualising the graph could be useful to help find your dependency issues, therefore a helper `generateModulesGraphvizText` task is included.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A Gradle plugin that helps keep your module graph healthy and lean.
 Apply the plugin to a module, which dependencies graph you want to assert.
 ```groovy
 plugins {
-  id "com.jraska.module.graph.assertion" version "1.7.0"
+  id "com.jraska.module.graph.assertion" version "2.0.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ moduleGraphAssert {
 <img src="https://user-images.githubusercontent.com/6277721/142781792-752f39ce-1525-4f59-8a25-94b236476117.png" width="300" />`
   - Each module would have set `ext.moduleNameAssertAlias = "Api|Implementation|App"`
   - Module rules example for such case: `allowed = ['Implementation -> Api', 'App -> .*']`
-  - In case you want to migrate to this structure incrementally, you can set a separate module type like `ext.moduleNameAssertAlias = "NeedsMigration"` and setting `allowed = ['Implementation -> Api', 'App -> .*', 'NeedsToMigrate -> .*', '.* -> NeedsToMigrate']` and then tackling `"NeedsToMigrate"` modules one by one.
+  - In case you want to migrate to this structure incrementally, you can set a separate module type like `ext.moduleNameAssertAlias = "NeedsMigration"` and setting `allowed = ['Implementation -> Api', 'App -> .*', 'NeedsMigration -> .*', '.* -> NeedsMigration']` and then tackling `"NeedsToMigrate"` modules one by one.
 
 ### Graphviz Graph Export
 - Visualising the graph could be useful to help find your dependency issues, therefore a helper `generateModulesGraphvizText` task is included.

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -35,7 +35,7 @@ pluginBundle {
   mavenCoordinates {
     groupId = 'com.jraska.module.graph.assertion'
     artifactId = 'plugin'
-    version = "1.7.0"
+    version = "2.0.0"
   }
 }
 
@@ -43,7 +43,7 @@ gradlePlugin {
   plugins {
     modulesGraphAssert {
       id = 'com.jraska.module.graph.assertion'
-      version = '1.7.0'
+      version = '2.0.0'
       displayName = 'Modules Graph Assert'
       description = 'Gradle plugin to keep your modules graph healthy and lean.'
       implementationClass = 'com.jraska.module.graph.assertion.ModuleGraphAssertionsPlugin'


### PR DESCRIPTION
### What's new
- #143 : You can now change the name for assertion by setting `ext.moduleNameAssertAlias = "ModuleNameAlias"` at any module.- this can be useful to use module types to enforce following structure:
<img src="https://user-images.githubusercontent.com/6277721/142781792-752f39ce-1525-4f59-8a25-94b236476117.png" width="300" />`
- #142: Configuration cache and task avoidance supported resolving 
- `allowed` syntax is not stable.
- #136 Kotlin 1.6.0 used.

### Migration from version 1.X
- ~~`moduleLayers`~~ are now removed in favour of `allowed` syntax. 
  - Example of migration: `moduleLayers = [":feature:\\S*", ":lib\\S*", ":core\\S*"]` -> `allowed = [":feature:\\S* -> :lib\\S*", ":feature:\\S* -> :core\\S*", :lib\\S* -> :core\\S*"]`
- `assertModuleLayers` doesn't exist anymore - `assertAllowedModuleDependencies` exists instead
- Parameter `modules.graph.print.statistics` is removed - use task `generateModulesGraphStatistics` instead
