### PR TITLE
Add custom logging configuration for restricted dependency assert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
     }
 }
-
+// Test commit
 allprojects {
   repositories {
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
     }
 }
-// Test commit
+
 allprojects {
   repositories {
     google()

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation gradleApi()
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10"
 
+  testImplementation "com.google.truth:truth:1.1.3"
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GraphRulesExtension.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GraphRulesExtension.kt
@@ -5,4 +5,5 @@ open class GraphRulesExtension {
   var restricted = emptyArray<String>() // each restriction in format "regexp -X> regexp" e.g.: ":feature-[a-z]* -X> :forbidden-lib"
   var allowed = emptyArray<String>() // each allowance in format "regexp -> regexp" e.g.: ":feature-[a-z]* -> :forbidden-lib"
   var configurations: Set<String> = Api.API_IMPLEMENTATON_CONFIGURATIONS
+  var customMessageOnRestrictedFailure: String? = null // custom message that displays when restricted dependencies task fails
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -92,7 +92,7 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
     }
 
     return tasks.register(Tasks.ASSERT_RESTRICTIONS, AssertGraphTask::class.java) {
-      it.assertion = RestrictedDependenciesAssert(graphRules.restricted, aliases)
+      it.assertion = RestrictedDependenciesAssert(graphRules.restricted, aliases, graphRules.customMessageOnRestrictedFailure)
       it.dependencyGraph = moduleGraph
       it.outputs.upToDateWhen { true }
       it.group = VERIFICATION_GROUP

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssert.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssert.kt
@@ -7,7 +7,8 @@ import org.gradle.api.GradleException
 
 class RestrictedDependenciesAssert(
   private val errorMatchers: Array<String>,
-  private val aliasMap: Map<String, String> = emptyMap()
+  private val aliasMap: Map<String, String> = emptyMap(),
+  private val customMessageOnRestrictedFailure: String? = null
 ) : GraphAssert {
   override fun assert(dependencyGraph: DependencyGraph) {
     val matchers = errorMatchers.map { Parse.restrictiveMatcher(it) }
@@ -28,6 +29,6 @@ class RestrictedDependenciesAssert(
     return failedDependencies.map {
       val violatedRules = it.second.map { "'$it'" }.joinToString(", ")
       "Dependency '${it.first.assertDisplayText()} violates: $violatedRules"
-    }.joinToString("\n")
+    }.joinToString("\n") + customMessageOnRestrictedFailure?.let { "\n" + it }.orEmpty()
   }
 }


### PR DESCRIPTION
#### Description
This PR adds an additional configuration parameter that allows clients to pass in a custom error message that gets appended to restricted dependency violations output. 

#### Reason
The reason for adding this new functionality is because I'd like to provide a custom error message with a link to documentation that explains to devs why the dependency is a violation.

#### Example
```groovy
moduleGraphAssert {
  maxHeight = 3
  restricted = [':example:app -X> :example:feature-[a-z]*']
  customMessageOnRestrictedFailure = "For more information on dependency violations " +
          "please follow the link: https://link.to.dependency.violations.documentation.com"
}
```
![image](https://user-images.githubusercontent.com/11139192/151687694-5587833e-8430-4c4e-ab74-62cdda1c5ef8.png)
