### PR TITLE
Accept multiple modules and generate json report for `generateModulesGraphStatistics`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ moduleGraphAssert {
 
 ### Graph statistics
 - Executing the task `generateModulesGraphStatistics` prints the information about the graph.
-- Statistics printed: Modules Count, [Edges Count](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#edge), [Height](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#height) and [Longest Path](https://en.wikipedia.org/wiki/Longest_path_problem) 
-- Parameter `-Pmodules.graph.of.module` is supported as well.
+- Statistics printed: Modules Count, [Edges Count](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#edge), [Height](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#height) and [Longest Path](https://en.wikipedia.org/wiki/Longest_path_problem)
+- Statistics report: The `generateModulesGraphStatistics` task will generate a report in JSON format. The report can be found at `<root>/build/graph/statistics/report.json`
+- Parameter `-Pmodules.graph.of.module` is supported as well. You can pass multiple modules separating them by `,` (ex: `-Pmodules.graph.of.module=:feature-one,:feature-two`)
 ```
 ./gradlew generateModulesGraphStatistics -Pmodules.graph.of.module=:feature-one
 ```

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id "com.gradle.plugin-publish" version "0.20.0"
   id "java-gradle-plugin"
+  id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.10'
 }
 
 apply plugin: 'kotlin'
@@ -12,6 +13,7 @@ repositories {
 dependencies {
   implementation gradleApi()
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10"
+  implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2'
 
   testImplementation 'junit:junit:4.13.2'
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+  id 'maven-publish'
   id "com.gradle.plugin-publish" version "0.20.0"
   id "java-gradle-plugin"
   id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.10'
@@ -8,6 +9,7 @@ apply plugin: 'kotlin'
 
 repositories {
   mavenCentral()
+  maven { url "https://jitpack.io" }
 }
 
 dependencies {

--- a/plugin/src/main/kotlin/com/jraska/module/graph/DependencyGraph.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/DependencyGraph.kt
@@ -51,6 +51,7 @@ class DependencyGraph private constructor() {
     val height = height()
     val edgesCount = countEdges()
     return GraphStatistics(
+      module = findRoot().key,
       modulesCount = nodes.size,
       edgesCount = edgesCount,
       height = height,

--- a/plugin/src/main/kotlin/com/jraska/module/graph/GraphStatistics.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/GraphStatistics.kt
@@ -1,8 +1,9 @@
 package com.jraska.module.graph
 
 data class GraphStatistics(
+  val module: String,
   val modulesCount: Int,
   val edgesCount: Int,
   val height: Int,
-  val longestPath: LongestPath
+  val longestPath: LongestPath,
 )

--- a/plugin/src/main/kotlin/com/jraska/module/graph/GraphStatistics.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/GraphStatistics.kt
@@ -1,5 +1,8 @@
 package com.jraska.module.graph
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class GraphStatistics(
   val module: String,
   val modulesCount: Int,

--- a/plugin/src/main/kotlin/com/jraska/module/graph/LongestPath.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/LongestPath.kt
@@ -1,5 +1,8 @@
 package com.jraska.module.graph
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class LongestPath(
   val nodeNames: List<String>
 ) {

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/report/ModuleGraphStatisticsReporter.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/report/ModuleGraphStatisticsReporter.kt
@@ -1,22 +1,18 @@
 package com.jraska.module.graph.assertion.report
 
 import com.jraska.module.graph.GraphStatistics
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToStream
 import org.gradle.api.invocation.Gradle
 import java.io.File
 
-@OptIn(ExperimentalSerializationApi::class)
 object ModuleGraphStatisticsReporter {
   private const val REPORT_FILE = "reports/graph/statistics/report.json"
 
   fun report(gradle: Gradle, statistics: List<GraphStatistics>) {
     File(gradle.rootProject.buildDir, REPORT_FILE)
       .createDirsAndFile()
-      .outputStream()
-      .use { Json.encodeToStream(ListSerializer(GraphStatistics.serializer()), statistics, it) }
+      .writeText(Json.encodeToString(ListSerializer(GraphStatistics.serializer()), statistics))
   }
 
   private fun File.createDirsAndFile() = run {

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/report/ModuleGraphStatisticsReporter.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/report/ModuleGraphStatisticsReporter.kt
@@ -1,0 +1,28 @@
+package com.jraska.module.graph.assertion.report
+
+import com.jraska.module.graph.GraphStatistics
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToStream
+import org.gradle.api.invocation.Gradle
+import java.io.File
+
+@OptIn(ExperimentalSerializationApi::class)
+object ModuleGraphStatisticsReporter {
+  private const val REPORT_FILE = "reports/graph/statistics/report.json"
+
+  fun report(gradle: Gradle, statistics: List<GraphStatistics>) {
+    File(gradle.rootProject.buildDir, REPORT_FILE)
+      .createDirsAndFile()
+      .outputStream()
+      .use { Json.encodeToStream(ListSerializer(GraphStatistics.serializer()), statistics, it) }
+  }
+
+  private fun File.createDirsAndFile() = run {
+    mkdirs()
+    delete()
+    createNewFile()
+    this
+  }
+}

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
@@ -1,5 +1,6 @@
 package com.jraska.module.graph.assertion.tasks
 
+import com.jraska.module.graph.assertion.report.ModuleGraphStatisticsReporter
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -11,6 +12,8 @@ open class GenerateModulesGraphStatisticsTask : DefaultTask() {
   @TaskAction
   fun run() {
     val dependencyGraph = project.createDependencyGraphs(configurationsToLook)
-    dependencyGraph.forEach { println(it.statistics()) }
+    val statistics = dependencyGraph.map { it.statistics() }
+    println(statistics)
+    ModuleGraphStatisticsReporter.report(gradle = project.gradle, statistics = statistics)
   }
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
@@ -10,7 +10,7 @@ open class GenerateModulesGraphStatisticsTask : DefaultTask() {
 
   @TaskAction
   fun run() {
-    val dependencyGraph = project.createDependencyGraph(configurationsToLook)
-    println(dependencyGraph.statistics())
+    val dependencyGraph = project.createDependencyGraphs(configurationsToLook)
+    dependencyGraph.forEach { println(it.statistics()) }
   }
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphTask.kt
@@ -54,3 +54,17 @@ internal fun Project.createDependencyGraph(configurationsToLook: Set<String>): D
 
   return dependencyGraph
 }
+
+internal fun Project.createDependencyGraphs(configurationsToLook: Set<String>): List<DependencyGraph> {
+  val dependencyGraph = GradleDependencyGraphFactory.create(this, configurationsToLook)
+
+  if (project.hasProperty(Api.Parameters.PRINT_ONLY_MODULE)) {
+    val moduleName = project.property(Api.Parameters.PRINT_ONLY_MODULE) as String?
+    val modules = moduleName?.split(",")?.map { it.trim() }
+    if (modules?.isNotEmpty() == true) {
+      return modules.map { dependencyGraph.subTree(it) }
+    }
+  }
+
+  return listOf(dependencyGraph)
+}


### PR DESCRIPTION
Hi @jraska

I was looking into the issues and there was a [feature request](https://github.com/jraska/modules-graph-assert/issues/77#issuecomment-707866274) created long ago which served +- as an inspiration for this PR. 

I'm working on the same team that Marcello was and my team is trying to continuously track the statistics of each feature module we have in our code base. At the moment the plugin has some limitations which this PR tries to solve
- Generate statistics to multiple modules
- Generate a report so that later this can be used by further automation

I wasn't sure if this is something you would like to have in the plugin, however after reading the issue comments I thought it could be a good idea to just go ahead and continue the discussion in a PR. Please feel free to challenge the new features added and i would totally understand if this is not something you would like to add to the plugin

Some technical decisions:
- I had to add a dependency to do JSON operations and i chose Kotlin Serialization.
- For the report generation I chose to put it in the build folder, much like the [Talaiot plugin](https://github.com/cdsap/Talaiot) also following their way to store the json file and generate the path
- For the parameter I just added the option to send multiple options by using commas `,`