### PR TITLE
Add task to calculate module metrics using JGraphT

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation gradleApi()
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21"
   implementation "org.jgrapht:jgrapht-core:1.5.1"
+  implementation 'com.jakewharton.picnic:picnic:0.6.0'
 
   testImplementation 'junit:junit:4.13.2'
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
   implementation gradleApi()
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21"
+  implementation "org.jgrapht:jgrapht-core:1.5.1"
 
   testImplementation 'junit:junit:4.13.2'
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/Api.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/Api.kt
@@ -4,6 +4,7 @@ object Api {
   object Tasks {
     const val GENERATE_GRAPHVIZ = "generateModulesGraphvizText"
     const val GENERATE_GRAPH_STATISTICS = "generateModulesGraphStatistics"
+    const val GENERATE_NODE_STATISTICS = "generateModulesGraphNodeStatistics"
 
     const val ASSERT_ALL = "assertModuleGraph"
     const val ASSERT_MAX_HEIGHT = "assertMaxHeight"

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -2,6 +2,7 @@ package com.jraska.module.graph.assertion
 
 import com.jraska.module.graph.assertion.Api.Tasks
 import com.jraska.module.graph.assertion.tasks.AssertGraphTask
+import com.jraska.module.graph.assertion.tasks.GenerateModulesGraphNodeStatisticsTask
 import com.jraska.module.graph.assertion.tasks.GenerateModulesGraphStatisticsTask
 import com.jraska.module.graph.assertion.tasks.GenerateModulesGraphTask
 import org.gradle.api.Plugin
@@ -39,6 +40,7 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
 
     project.addModuleGraphGeneration(graphRules)
     project.addModuleGraphStatisticsGeneration(graphRules)
+    project.addModuleNodeStatisticsGeneration(graphRules)
 
     val allAssertionsTask = project.tasks.register(Tasks.ASSERT_ALL) { it.group = VERIFICATION_GROUP }
 
@@ -69,6 +71,12 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
 
   private fun Project.addModuleGraphStatisticsGeneration(graphRules: GraphRulesExtension) {
     tasks.register(Tasks.GENERATE_GRAPH_STATISTICS, GenerateModulesGraphStatisticsTask::class.java) {
+      it.configurationsToLook = graphRules.configurations
+    }
+  }
+
+  private fun Project.addModuleNodeStatisticsGeneration(graphRules: GraphRulesExtension) {
+    tasks.register(Tasks.GENERATE_NODE_STATISTICS, GenerateModulesGraphNodeStatisticsTask::class.java) {
       it.configurationsToLook = graphRules.configurations
     }
   }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphNodeStatisticsTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphNodeStatisticsTask.kt
@@ -1,5 +1,7 @@
 package com.jraska.module.graph.assertion.tasks
 
+import com.jakewharton.picnic.renderText
+import com.jakewharton.picnic.table
 import com.jraska.module.graph.DependencyGraph
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -16,7 +18,32 @@ open class GenerateModulesGraphNodeStatisticsTask : DefaultTask() {
   fun run() {
     val dependencyGraph = project.createDependencyGraph(configurationsToLook)
     val nodeStatistics = dependencyGraph.nodeStatistics()
-    nodeStatistics.forEach(::println)
+    table {
+      cellStyle {
+        paddingLeft = 1
+        paddingRight = 1
+      }
+      header {
+        row(
+          "node",
+          "betweennessCentrality",
+          "degree",
+          "inDegree",
+          "outDegree",
+          "height"
+        )
+      }
+      nodeStatistics.forEach {
+        row(
+          it.node,
+          "%.2f".format(it.betweennessCentrality),
+          it.degree,
+          it.inDegree,
+          it.outDegree,
+          it.height
+        )
+      }
+    }.renderText().let(::println)
   }
 
   data class NodeStatistics(

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphNodeStatisticsTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphNodeStatisticsTask.kt
@@ -1,0 +1,62 @@
+package com.jraska.module.graph.assertion.tasks
+
+import com.jraska.module.graph.DependencyGraph
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.jgrapht.alg.scoring.BetweennessCentrality
+import org.jgrapht.graph.DefaultDirectedGraph
+import org.jgrapht.graph.DefaultEdge
+
+open class GenerateModulesGraphNodeStatisticsTask : DefaultTask() {
+  @Input
+  lateinit var configurationsToLook: Set<String>
+
+  @TaskAction
+  fun run() {
+    val dependencyGraph = project.createDependencyGraph(configurationsToLook)
+    val nodeStatistics = dependencyGraph.nodeStatistics()
+    nodeStatistics.forEach(::println)
+  }
+
+  data class NodeStatistics(
+    val node: String,
+    val betweennessCentrality: Double,
+    val degree: Int,
+    val inDegree: Int,
+    val outDegree: Int,
+    val height: Int
+  )
+
+  private fun DependencyGraph.nodeStatistics(): List<NodeStatistics> {
+    val g = toJGraphTGraph()
+    val betweennessCentrality = BetweennessCentrality(g).scores
+    return g.vertexSet().map { node ->
+      NodeStatistics(
+        node = node,
+        betweennessCentrality = requireNotNull(betweennessCentrality[node]) {
+          "Betweenness not found for $node"
+        },
+        degree = g.degreeOf(node),
+        inDegree = g.inDegreeOf(node),
+        outDegree = g.outDegreeOf(node),
+        height = heightOf(node)
+      )
+    }.sortedByDescending {
+      it.betweennessCentrality
+    }
+  }
+
+  private fun DependencyGraph.toJGraphTGraph(): DefaultDirectedGraph<String, DefaultEdge> {
+    val g = DefaultDirectedGraph<String, DefaultEdge>(DefaultEdge::class.java)
+    nodes().forEach {
+      g.addVertex(it.key)
+    }
+    nodes().forEach { n1 ->
+      n1.dependsOn.forEach { n2 ->
+        g.addEdge(n1.key, n2.key)
+      }
+    }
+    return g
+  }
+}


### PR DESCRIPTION
## Change
Add new task `generateModulesGraphNodeStatistics` showing betweenness centrality, degree, in degree, out degree as well as the height for all modules in a modules graph.

Adds `picnic` and `jgrapht-core` as dependencies

## Example output
```
$ gw generateModulesGraphNodeStatistics

 node                betweennessCentrality  degree  inDegree  outDegree  height 
 :core-data          18.00                  10      5         5          2      
 :sync               2.10                   5       1         4          3      
 :feature-author     1.10                   6       1         5          3      
 :feature-topic      1.10                   6       1         5          3      
 :feature-interests  0.77                   5       1         4          3      
 :feature-foryou     0.77                   5       1         4          3      
 :core-ui            0.17                   6       5         1          1      
 :app                0.00                   7       0         7          4      
 :core-model         0.00                   9       9         0          0      
 :core-common        0.00                   6       6         0          0      
 :core-database      0.00                   2       1         1          1      
 :core-datastore     0.00                   3       2         1          1      
 :core-network       0.00                   3       1         2          1      
 :core-navigation    0.00                   5       5         0          0   
```