### PR TITLE
Add option to assert on each build

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GraphRulesExtension.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GraphRulesExtension.kt
@@ -5,4 +5,11 @@ open class GraphRulesExtension {
   var restricted = emptyArray<String>() // each restriction in format "regexp -X> regexp" e.g.: ":feature-[a-z]* -X> :forbidden-lib"
   var allowed = emptyArray<String>() // each allowance in format "regexp -> regexp" e.g.: ":feature-[a-z]* -> :forbidden-lib"
   var configurations: Set<String> = Api.API_IMPLEMENTATON_CONFIGURATIONS
+  var assertOnAnyBuild: Boolean = false
+
+  internal fun shouldAssertHeight() = maxHeight > 0
+
+  internal fun shouldAssertRestricted() = restricted.isNotEmpty()
+
+  internal fun shouldAssertAllowed() = allowed.isNotEmpty()
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -105,15 +105,15 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
   }
 
   private fun Project.addMaxHeightTask(graphRules: GraphRulesExtension): TaskProvider<AssertGraphTask>? {
-    if (!graphRules.shouldAssertHeight()) {
+    if (graphRules.shouldAssertHeight()) {
+      return tasks.register(Tasks.ASSERT_MAX_HEIGHT, AssertGraphTask::class.java) {
+        it.assertion = moduleTreeHeightAssert(graphRules)
+        it.dependencyGraph = moduleGraph
+        it.outputs.upToDateWhen { true }
+        it.group = VERIFICATION_GROUP
+      }
+    } else {
       return null
-    }
-
-    return tasks.register(Tasks.ASSERT_MAX_HEIGHT, AssertGraphTask::class.java) {
-      it.assertion = moduleTreeHeightAssert(graphRules)
-      it.dependencyGraph = moduleGraph
-      it.outputs.upToDateWhen { true }
-      it.group = VERIFICATION_GROUP
     }
   }
 
@@ -121,15 +121,15 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
     ModuleTreeHeightAssert(moduleNameForHeightAssert(), graphRules.maxHeight)
 
   private fun Project.addModuleRestrictionsTask(graphRules: GraphRulesExtension): TaskProvider<AssertGraphTask>? {
-    if (!graphRules.shouldAssertRestricted()) {
+    if (graphRules.shouldAssertRestricted()) {
+      return tasks.register(Tasks.ASSERT_RESTRICTIONS, AssertGraphTask::class.java) {
+        it.assertion = restrictedDependenciesAssert(graphRules)
+        it.dependencyGraph = moduleGraph
+        it.outputs.upToDateWhen { true }
+        it.group = VERIFICATION_GROUP
+      }
+    } else {
       return null
-    }
-
-    return tasks.register(Tasks.ASSERT_RESTRICTIONS, AssertGraphTask::class.java) {
-      it.assertion = restrictedDependenciesAssert(graphRules)
-      it.dependencyGraph = moduleGraph
-      it.outputs.upToDateWhen { true }
-      it.group = VERIFICATION_GROUP
     }
   }
 
@@ -137,15 +137,15 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
     RestrictedDependenciesAssert(graphRules.restricted, aliases)
 
   private fun Project.addModuleAllowedRulesTask(graphRules: GraphRulesExtension): TaskProvider<AssertGraphTask>? {
-    if (!graphRules.shouldAssertAllowed()) {
+    if (graphRules.shouldAssertAllowed()) {
+      return tasks.register(Tasks.ASSERT_ALLOWED, AssertGraphTask::class.java) {
+        it.assertion = onlyAllowedAssert(graphRules)
+        it.dependencyGraph = moduleGraph
+        it.outputs.upToDateWhen { true }
+        it.group = VERIFICATION_GROUP
+      }
+    } else {
       return null
-    }
-
-    return tasks.register(Tasks.ASSERT_ALLOWED, AssertGraphTask::class.java) {
-      it.assertion = onlyAllowedAssert(graphRules)
-      it.dependencyGraph = moduleGraph
-      it.outputs.upToDateWhen { true }
-      it.group = VERIFICATION_GROUP
     }
   }
 

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -27,11 +27,7 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
   private lateinit var configurationsToLook: Set<String>
 
   override fun apply(project: Project) {
-    val graphRules = project.extensions.create(
-      GraphRulesExtension::class.java,
-      Api.EXTENSION_ROOT,
-      GraphRulesExtension::class.java
-    )
+    val graphRules = project.extensions.create(GraphRulesExtension::class.java, Api.EXTENSION_ROOT, GraphRulesExtension::class.java)
 
     project.afterEvaluate {
       addModulesAssertions(project, graphRules)
@@ -51,8 +47,7 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
     project.addModuleGraphGeneration(graphRules)
     project.addModuleGraphStatisticsGeneration(graphRules)
 
-    val allAssertionsTask =
-      project.tasks.register(Tasks.ASSERT_ALL) { it.group = VERIFICATION_GROUP }
+    val allAssertionsTask = project.tasks.register(Tasks.ASSERT_ALL) { it.group = VERIFICATION_GROUP }
 
     try {
       project.tasks.named(CHECK_TASK_NAME).configure { it.dependsOn(allAssertionsTask) }

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/OnAnyBuildAssertTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/OnAnyBuildAssertTest.kt
@@ -1,0 +1,167 @@
+package com.jraska.module.graph.assertion
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class OnAnyBuildAssertTest {
+  @get:Rule
+  val testProjectDir: TemporaryFolder = TemporaryFolder()
+
+  @Before
+  fun setup() {
+    testProjectDir.newFile("settings.gradle")
+      .writeText("include ':app', ':core', ':feature', 'core-api'")
+
+    createModule(
+      "core-api", content = """
+      apply plugin: 'java-library'
+      
+      ext.moduleNameAssertAlias = "Api"
+      """
+    )
+
+    createModule(
+      "core", content = """
+      apply plugin: 'java-library'
+
+      dependencies {
+        implementation project(":core-api")
+      }
+      ext.moduleNameAssertAlias = "Implementation"
+      """
+    )
+
+    createModule(
+      "feature", content = """
+      apply plugin: 'java-library'
+
+      dependencies {
+        implementation project(":core-api")
+      }
+      
+      ext.moduleNameAssertAlias = "Implementation"
+      """
+    )
+  }
+
+  private fun createAppModule(moduleGraphAssertConfiguration: String) {
+    createModule(
+      "app", content = """
+          plugins {
+              id 'com.jraska.module.graph.assertion'
+          }
+          apply plugin: 'java-library'
+          
+          $moduleGraphAssertConfiguration
+          
+          dependencies {
+            implementation project(":core-api")
+            implementation project(":core")
+            implementation project(":feature")
+          }
+     
+          ext.moduleNameAssertAlias = "App"
+      """
+    )
+  }
+
+  @Test
+  fun failsOnEvaluationCheckMaxHeight() {
+    createAppModule(
+      """
+          moduleGraphAssert {
+            maxHeight = 1
+            assertOnAnyBuild = true
+          }   
+      """
+    )
+
+    val output = setupGradle(testProjectDir.root, "help").buildAndFail().output
+
+    assert(output.contains("Module :app is allowed to have maximum height of 1, but has 2, problematic dependencies: :app -> :core -> :core-api"))
+  }
+
+  @Test
+  fun whenNotAssertOnEachEvaluation_succeedsOnEvaluationCheckMaxHeight() {
+    createAppModule(
+      """
+          moduleGraphAssert {
+            maxHeight = 1
+            assertOnAnyBuild = false
+          }   
+      """
+    )
+
+    val output = setupGradle(testProjectDir.root, "help").build().output
+    assert(output.contains("BUILD SUCCESS"))
+
+    setupGradle(testProjectDir.root, "assertModuleGraph").buildAndFail()
+  }
+
+  @Test
+  fun failsOnEvaluationCheckAllowed() {
+    createAppModule(
+      """
+          moduleGraphAssert {
+            allowed = ['Implementation -> Api', 'App -> Api']
+            assertOnAnyBuild = true
+          }   
+      """
+    )
+
+    val output = setupGradle(testProjectDir.root, "help").buildAndFail().output
+
+    assert(output.contains("""["App"(':app') -> "Implementation"(':core'), "App"(':app') -> "Implementation"(':feature')] not allowed by any of ['Implementation -> Api', 'App -> Api']"""))
+  }
+
+  @Test
+  fun whenNotAssertOnEachEvaluationDefault_succeedsOnEvaluationCheckAllowed() {
+    createAppModule(
+      """
+          moduleGraphAssert {
+            allowed = ['Implementation -> Api', 'App -> Api']
+          }   
+      """
+    )
+
+    val output = setupGradle(testProjectDir.root, "help").build().output
+    assert(output.contains("BUILD SUCCESS"))
+
+    setupGradle(testProjectDir.root, "assertModuleGraph").buildAndFail()
+  }
+
+  @Test
+  fun failsOnEvaluationCheckRestricted() {
+    createAppModule(
+      """
+          moduleGraphAssert {
+            restricted = ['App -X> Api', 'Implementation -X> Implementation']
+            assertOnAnyBuild = true
+          }   
+      """
+    )
+
+    val output = setupGradle(testProjectDir.root, "help").buildAndFail().output
+
+    assert(output.contains("""Dependency '"App"(':app') -> "Api"(':core-api') violates: 'App -X> Api'"""))
+  }
+
+  private fun createModule(dir: String, content: String) {
+    val newFolder = testProjectDir.newFolder(dir)
+    File(newFolder, "build.gradle").writeText(content)
+  }
+
+  private fun setupGradle(
+    dir: File,
+    vararg arguments: String
+  ): GradleRunner {
+    return GradleRunner.create()
+      .withProjectDir(dir)
+      .withPluginClasspath()
+      .withArguments(arguments.asList())
+  }
+}


### PR DESCRIPTION
- Engineers typically won't run the assertion locally - the use case it to run the assertions as part of each build to immediately notify engineers at the first build after added dependency.
- The assertion typically takes < 10ms (tried [this graph](https://github.com/jraska/modules-graph-assert/blob/master/plugin/src/test/kotlin/com/jraska/module/graph/DependencyGraphPerformanceTest.kt#L26-L29) on M1 machine), therefore running it on any build takes neglectable amount of time
- Related to #166 
- The #166 will be resolved after the new version is released and documentation is added to README.