### PR TITLE
Remove unnecessary map

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/DependencyGraph.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/DependencyGraph.kt
@@ -101,7 +101,7 @@ class DependencyGraph private constructor() {
       if (isLeaf()) {
         0
       } else {
-        1 + dependsOn.map { it.height() }.maxOrNull()!!
+        1 + dependsOn.maxOf { it.height() }
       }
     }
 


### PR DESCRIPTION
- Extra collection was created just to iterate again
- The measured performance effect of this particular change was neglectable, doing it for cleaning
- Measured performance on M1 machine was 1200ms for 500 passes of [this graph](https://github.com/jraska/modules-graph-assert/blob/master/plugin/src/test/kotlin/com/jraska/module/graph/DependencyGraphPerformanceTest.kt#L26-L29) WITH 1000 modules - giving **4.2ms** cost of passing such graph