### PR TITLE
Unify Kotlin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
-    }
+  ext.kotlin_version = '1.8.10'
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
 }
 
 allprojects {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
   implementation gradleApi()
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
   testImplementation 'junit:junit:4.13.2'
 }


### PR DESCRIPTION
- Use variable to not duplicate. 
- Make Dependabot happy - one PR per Kotlin update, not two