### PR TITLE
Graphing features supporting configuration cache

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -44,8 +44,8 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
     evaluatedProject = project
     configurationsToLook = graphRules.configurations
 
-    project.addModuleGraphGeneration(graphRules)
-    project.addModuleGraphStatisticsGeneration(graphRules)
+    project.addModuleGraphGeneration()
+    project.addModuleGraphStatisticsGeneration()
 
     val allAssertionsTask = project.tasks.register(Tasks.ASSERT_ALL) { it.group = VERIFICATION_GROUP }
 
@@ -83,19 +83,21 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
     }
   }
 
-  private fun Project.addModuleGraphGeneration(graphRules: GraphRulesExtension) {
+  private fun Project.addModuleGraphGeneration() {
     tasks.register(Tasks.GENERATE_GRAPHVIZ, GenerateModulesGraphTask::class.java) {
-      it.configurationsToLook = graphRules.configurations
+      it.dependencyGraph = moduleGraph
       it.aliases = aliases
+      it.outputFilePath = GenerateModulesGraphTask.outputFilePath(this)
+      it.onlyModuleToPrint = GenerateModulesGraphTask.onlyModuleToPrint(this)
     }
   }
 
-  private fun Project.addModuleGraphStatisticsGeneration(graphRules: GraphRulesExtension) {
+  private fun Project.addModuleGraphStatisticsGeneration() {
     tasks.register(
       Tasks.GENERATE_GRAPH_STATISTICS,
       GenerateModulesGraphStatisticsTask::class.java
     ) {
-      it.configurationsToLook = graphRules.configurations
+      it.dependencyGraph = moduleGraph
     }
   }
 

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphStatisticsTask.kt
@@ -1,16 +1,17 @@
 package com.jraska.module.graph.assertion.tasks
 
+import com.jraska.module.graph.DependencyGraph
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 open class GenerateModulesGraphStatisticsTask : DefaultTask() {
   @Input
-  lateinit var configurationsToLook: Set<String>
+  lateinit var dependencyGraph: DependencyGraph.SerializableGraph
 
   @TaskAction
   fun run() {
-    val dependencyGraph = project.createDependencyGraph(configurationsToLook)
+    val dependencyGraph = DependencyGraph.create(dependencyGraph)
     println(dependencyGraph.statistics())
   }
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphTask.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/tasks/GenerateModulesGraphTask.kt
@@ -3,54 +3,71 @@ package com.jraska.module.graph.assertion.tasks
 import com.jraska.module.graph.DependencyGraph
 import com.jraska.module.graph.GraphvizWriter
 import com.jraska.module.graph.assertion.Api
-import com.jraska.module.graph.assertion.GradleDependencyGraphFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class GenerateModulesGraphTask : DefaultTask() {
-  @Input
-  lateinit var configurationsToLook: Set<String>
 
   @Input
   lateinit var aliases: Map<String, String>
 
+  @Optional
+  @Input
+  var onlyModuleToPrint: String? = null
+
+  @Input
+  lateinit var dependencyGraph: DependencyGraph.SerializableGraph
+
+  @Optional
+  @Input
+  var outputFilePath: String? = null
+
+  @Optional
+  @OutputFile
+  var outputFile: File? = null
+
   @TaskAction
   fun run() {
-    val dependencyGraph = project.createDependencyGraph(configurationsToLook)
+    val dependencyGraph = DependencyGraph.create(dependencyGraph).let {
+      if (onlyModuleToPrint == null) {
+        it
+      } else {
+        it.subTree(onlyModuleToPrint!!)
+      }
+    }
 
     val graphviz = GraphvizWriter.toGraphviz(dependencyGraph, aliases)
 
-    if (shouldOutputFile()) {
-      getOutputFile().apply {
-        println("GraphViz saved to $path")
-        writeText(graphviz)
-      }
+    if (outputFilePath != null) {
+      val file = File(outputFilePath!!)
+      file.writeText(graphviz)
+      outputFile = file
+      println("GraphViz saved to $path")
     } else {
       println(graphviz)
     }
   }
 
-  private fun shouldOutputFile(): Boolean {
-    return project.hasProperty(Api.Parameters.OUTPUT_PATH)
-  }
+  companion object {
+    internal fun outputFilePath(project: Project): String? {
+      if (project.hasProperty(Api.Parameters.OUTPUT_PATH)) {
+        return project.property(Api.Parameters.OUTPUT_PATH).toString()
+      } else {
+        return null
+      }
+    }
 
-  private fun getOutputFile(): File {
-    return File(project.property(Api.Parameters.OUTPUT_PATH).toString())
-  }
-}
-
-internal fun Project.createDependencyGraph(configurationsToLook: Set<String>): DependencyGraph {
-  val dependencyGraph = GradleDependencyGraphFactory.create(this, configurationsToLook)
-
-  if (project.hasProperty(Api.Parameters.PRINT_ONLY_MODULE)) {
-    val moduleName = project.property(Api.Parameters.PRINT_ONLY_MODULE) as String?
-    if (moduleName != null) {
-      return dependencyGraph.subTree(moduleName)
+    internal fun onlyModuleToPrint(project: Project): String? {
+      if (project.hasProperty(Api.Parameters.PRINT_ONLY_MODULE)) {
+        return project.property(Api.Parameters.PRINT_ONLY_MODULE) as String?
+      } else {
+        return null
+      }
     }
   }
-
-  return dependencyGraph
 }

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectGradleTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectGradleTest.kt
@@ -78,14 +78,58 @@ class FullProjectGradleTest {
   }
 
   @Test
+  fun statisticsSupportConfigurationCache() {
+    runGradleAssertModuleGraph(testProjectDir.root, "--configuration-cache", "generateModulesGraphStatistics")
+    val secondRunResult = runGradleAssertModuleGraph(testProjectDir.root, "--configuration-cache", "generateModulesGraphStatistics")
+
+    assert(secondRunResult.output.contains("Reusing configuration cache."))
+  }
+
+  @Test
+  fun moduleGraphSupportConfigurationCache() {
+    runGradleAssertModuleGraph(testProjectDir.root, "--configuration-cache", "generateModulesGraphvizText")
+    val secondRunResult = runGradleAssertModuleGraph(testProjectDir.root, "--configuration-cache", "generateModulesGraphvizText")
+
+    assert(secondRunResult.output.contains("Reusing configuration cache."))
+  }
+
+  @Test
   fun printsCorrectStatistics() {
     val output = runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphStatistics").output
 
     assert(output.contains("GraphStatistics(modulesCount=4, edgesCount=5, height=2, longestPath=':app -> :core -> :core-api')"))
   }
 
+  @Test
+  fun printsOnlyModule() {
+    val output = runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphvizText", "-Pmodules.graph.of.module=:feature").output
+
+    assert(output.contains("digraph G {\n" +
+      "\":feature('Implementation')\" -> \":core-api('Api')\" [color=red style=bold]\n" +
+      "}"))
+  }
+
+  @Test
+  fun savesGraphIntoFile() {
+    val outputFile = File(testProjectDir.root, "all_modules.dot")
+    val output = runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphvizText", "-Pmodules.graph.output.gv=${outputFile.absolutePath}").output
+
+    assert(output.contains("GraphViz saved to"))
+    assert(outputFile.readText() == EXPECTED_GRAPHVIZ_TEXT)
+  }
+
   private fun createModule(dir: String, content: String) {
     val newFolder = testProjectDir.newFolder(dir)
     File(newFolder, "build.gradle").writeText(content)
+  }
+
+  companion object {
+    const val EXPECTED_GRAPHVIZ_TEXT = """digraph G {
+":app('App')" -> ":core-api('Api')"
+":app('App')" -> ":core('Implementation')" [color=red style=bold]
+":app('App')" -> ":feature('Implementation')"
+":core('Implementation')" -> ":core-api('Api')" [color=red style=bold]
+":feature('Implementation')" -> ":core-api('Api')"
+}"""
   }
 }


### PR DESCRIPTION
- it is inconvenient for users o use `--no-configuration-cache` whilst having configuration cache enabled for tasks `generateModulesGraphvizText` and `generateModulesGraphStatistics`, therefore changes were made to support the configuration cache for those cases
- Bunch of end-to-end tests added on a way to verify the functionality