### PR TITLE
Add support for `rootProject` as a dependency

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleDependencyGraphFactory.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleDependencyGraphFactory.kt
@@ -30,7 +30,7 @@ object GradleDependencyGraphFactory {
   }
 
   private fun Project.listAllDependencies(configurationsToLook: Set<String>): List<Pair<String, List<String>>> {
-    return allprojects
+    return (rootProject.subprojects + rootProject)
       .map { project ->
         project.moduleDisplayName() to project.configurations
           .filter { configurationsToLook.contains(it.name) }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleDependencyGraphFactory.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleDependencyGraphFactory.kt
@@ -30,7 +30,7 @@ object GradleDependencyGraphFactory {
   }
 
   private fun Project.listAllDependencies(configurationsToLook: Set<String>): List<Pair<String, List<String>>> {
-    return rootProject.subprojects
+    return allprojects
       .map { project ->
         project.moduleDisplayName() to project.configurations
           .filter { configurationsToLook.contains(it.name) }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleModuleAliasExtractor.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleModuleAliasExtractor.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Project
 
 object GradleModuleAliasExtractor {
   fun extractModuleAliases(project: Project): Map<String, String> {
-    return project.rootProject.subprojects
+    return project.allprojects
       .mapNotNull { alias(it) }
       .toMap()
   }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleModuleAliasExtractor.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GradleModuleAliasExtractor.kt
@@ -4,7 +4,8 @@ import org.gradle.api.Project
 
 object GradleModuleAliasExtractor {
   fun extractModuleAliases(project: Project): Map<String, String> {
-    return project.allprojects
+    val rootProject = project.rootProject
+    return (rootProject.subprojects + rootProject)
       .mapNotNull { alias(it) }
       .toMap()
   }

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectRootGradleTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectRootGradleTest.kt
@@ -1,0 +1,89 @@
+package com.jraska.module.graph.assertion
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class FullProjectRootGradleTest {
+  @get:Rule
+  val testProjectDir: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun printsCorrectStatisticsForRootProjectWithDependency() {
+    testProjectDir.newFile("settings.gradle")
+      .writeText("include ':core'")
+
+    createRoot(content = """
+      plugins {
+          id 'com.jraska.module.graph.assertion'
+      }
+      apply plugin: 'java-library'
+      
+      moduleGraphAssert {
+        maxHeight = 1
+      }
+      dependencies {
+        implementation project(":core")
+      }
+    """.trimIndent())
+
+    createModule(
+      "core", content = """
+      apply plugin: 'java-library'
+      """
+    )
+
+    val output =
+      runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphStatistics").output
+
+    assert(output.contains(("> Task :generateModulesGraphStatistics\n.*" +
+      "GraphStatistics\\(modulesCount=2, edgesCount=1, height=1, longestPath=\'root.* -> :core\'\\)").toRegex()))
+  }
+
+  @Test
+  fun printsCorrectStatisticsForIndependentRootProject() {
+    testProjectDir.newFile("settings.gradle")
+      .writeText("include ':app'")
+
+    createRoot(content = """
+      plugins {
+          id 'com.jraska.module.graph.assertion'
+      }
+      apply plugin: 'java-library'
+      
+      moduleGraphAssert {
+        maxHeight = 0
+      }
+    """.trimIndent())
+
+    createModule(
+      "app", content = """
+      plugins {
+          id 'com.jraska.module.graph.assertion'
+      }
+      apply plugin: 'java-library'
+      moduleGraphAssert {
+        maxHeight = 0
+      }
+      """
+    )
+
+    val output =
+      runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphStatistics").output
+
+    assert(output.contains(("> Task :generateModulesGraphStatistics\n.*" +
+      "GraphStatistics\\(modulesCount=1, edgesCount=0, height=0, longestPath=\'root.*\'\\)\n\n" +
+      "> Task :app:generateModulesGraphStatistics\n+" +
+      "GraphStatistics\\(modulesCount=1, edgesCount=0, height=0, longestPath=\':app\'\\)").toRegex()))
+  }
+
+  private fun createRoot(content: String) {
+    File(testProjectDir.root, "build.gradle").writeText(content)
+  }
+
+  private fun createModule(dir: String, content: String) {
+    val newFolder = testProjectDir.newFolder(dir)
+    File(newFolder, "build.gradle").writeText(content)
+  }
+}


### PR DESCRIPTION
- Adds support for `rootProject` as a dependency
- Fixes https://github.com/jraska/modules-graph-assert/issues/232
