### PR TITLE
Fix alias evaluation that was only evaluated once

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -19,9 +19,8 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
     GradleDependencyGraphFactory.create(evaluatedProject, configurationsToLook).serializableGraph()
   }
 
-  private val aliases by lazy {
-    GradleModuleAliasExtractor.extractModuleAliases(evaluatedProject)
-  }
+  private val aliases : Map<String, String>
+    get() = GradleModuleAliasExtractor.extractModuleAliases(evaluatedProject)
 
   private lateinit var evaluatedProject: Project
   private lateinit var configurationsToLook: Set<String>


### PR DESCRIPTION
The alias evaluation was only applied to the app module and also for the highest or fastest to compile module. Since the property is lazy it was evaluated once for all other modules.

Fixes this issue https://github.com/jraska/modules-graph-assert/issues/238