### PR TITLE
Remove unnecessary interface

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/DependencyMatcher.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/DependencyMatcher.kt
@@ -1,5 +1,0 @@
-package com.jraska.module.graph
-
-interface DependencyMatcher {
-  fun matches(dependency: Pair<String, String>): Boolean
-}

--- a/plugin/src/main/kotlin/com/jraska/module/graph/RegexpDependencyMatcher.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/RegexpDependencyMatcher.kt
@@ -3,9 +3,9 @@ package com.jraska.module.graph
 class RegexpDependencyMatcher(
   private val matchingRegex: Regex,
   private val divider: String
-) : DependencyMatcher {
+) {
 
-  override fun matches(dependency: Pair<String, String>): Boolean {
+  fun matches(dependency: Pair<String, String>): Boolean {
     val dependencyToMatch = "${dependency.first}$divider${dependency.second}"
     return matchingRegex.matches(dependencyToMatch)
   }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssert.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssert.kt
@@ -1,8 +1,8 @@
 package com.jraska.module.graph.assertion
 
 import com.jraska.module.graph.DependencyGraph
-import com.jraska.module.graph.DependencyMatcher
 import com.jraska.module.graph.Parse
+import com.jraska.module.graph.RegexpDependencyMatcher
 import org.gradle.api.GradleException
 
 class RestrictedDependenciesAssert(
@@ -24,7 +24,7 @@ class RestrictedDependenciesAssert(
     }
   }
 
-  private fun buildErrorMessage(failedDependencies: List<Pair<ModuleDependency, List<DependencyMatcher>>>): String {
+  private fun buildErrorMessage(failedDependencies: List<Pair<ModuleDependency, List<RegexpDependencyMatcher>>>): String {
     return failedDependencies.map {
       val violatedRules = it.second.map { "'$it'" }.joinToString(", ")
       "Dependency '${it.first.assertDisplayText()} violates: $violatedRules"


### PR DESCRIPTION
- Single implementation of `DependencyMatcher`
- Interface deemed unnecessary