### PR TITLE
Allowed Violations

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GraphRulesExtension.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/GraphRulesExtension.kt
@@ -4,6 +4,7 @@ open class GraphRulesExtension {
   var maxHeight: Int = 0
   var restricted = emptyArray<String>() // each restriction in format "regexp -X> regexp" e.g.: ":feature-[a-z]* -X> :forbidden-lib"
   var allowed = emptyArray<String>() // each allowance in format "regexp -> regexp" e.g.: ":feature-[a-z]* -> :forbidden-lib"
+  var allowedViolations = emptyMap<String, List<String>>() // each allowed violation in the format ["feature-[a-z]*" : [forbidden-lib1, forbidden-lib2]]
   var configurations: Set<String> = Api.API_IMPLEMENTATION_CONFIGURATIONS
   var assertOnAnyBuild: Boolean = false
 

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleGraphAssertionsPlugin.kt
@@ -148,7 +148,7 @@ class ModuleGraphAssertionsPlugin : Plugin<Project> {
   }
 
   private fun onlyAllowedAssert(graphRules: GraphRulesExtension) =
-    OnlyAllowedAssert(graphRules.allowed, aliases)
+    OnlyAllowedAssert(graphRules.allowed, aliases, graphRules.allowedViolations)
 }
 
 private fun Project.moduleNameForHeightAssert(): String? {

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/OnlyAllowedAssertTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/OnlyAllowedAssertTest.kt
@@ -70,6 +70,25 @@ class OnlyAllowedAssertTest {
     OnlyAllowedAssert(allowedDependencies, aliases).assert(dependencyGraph)
   }
 
+  @Test
+  fun passesWhenViolationIsAllowed() {
+    val dependencies = testGraph().dependencyPairs().toMutableList().apply { add("api" to "lib2") }
+    val dependencyGraph = DependencyGraph.create(dependencies)
+
+    val allowedDependencies = arrayOf(
+      "app -> .*",
+      "feature[a-z]* -> lib[0-9]*",
+      "feature[a-z]* -> api[0-9]*",
+      "api[0-9]* -> lib",
+    )
+
+    val allowedViolations = mapOf(
+      "api" to listOf("lib2")
+    )
+
+    OnlyAllowedAssert(allowedDependencies, allowedViolations = allowedViolations).assert(dependencyGraph)
+  }
+
   private fun testGraph(): DependencyGraph {
     return DependencyGraph.create(
       "app" to "feature",


### PR DESCRIPTION
This is a potential solution to this [issue](https://github.com/jraska/modules-graph-assert/issues/203). What I am hoping to achieve is to be able to pass in a map of modules and a list of their violated dependency modules and have the plugin accept this list of violations and not flag it as a violation. 