### PR TITLE
Add license information to POM file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,11 @@ VERSION_NAME=0.1.0
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
+
+POM_DESCRIPTION=Gradle plugin to keep your modules graph healthy and lean.
+POM_URL=https://github.com/jraska/modules-graph-assert
+POM_NAME=Modules Graph Assert
+
+POM_SCM_URL=https://github.com/jraska/modules-graph-assert
+POM_SCM_CONNECTION=scm:git:git://github.com/jraska/modules-graph-assert.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com/jraska/modules-graph-assert.git

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -34,17 +34,38 @@ java {
 group = 'com.jraska.module.graph.assertion'
 
 gradlePlugin {
-  website = 'https://github.com/jraska/modules-graph-assert'
-  vcsUrl = 'https://github.com/jraska/modules-graph-assert'
+  website = POM_URL
+  vcsUrl = POM_URL
 
   plugins {
     modulesGraphAssert {
       id = 'com.jraska.module.graph.assertion'
       version = '2.7.2'
-      displayName = 'Modules Graph Assert'
-      description = 'Gradle plugin to keep your modules graph healthy and lean.'
+      displayName = POM_NAME
+      description = POM_DESCRIPTION
       implementationClass = 'com.jraska.module.graph.assertion.ModuleGraphAssertionsPlugin'
       tags.addAll('graph', 'assert', 'build speed', 'android', 'java', 'kotlin', 'quality', 'multiprojects', 'module')
+    }
+  }
+}
+
+afterEvaluate {
+  publishing.publications.forEach {
+    it.pom {
+      name = POM_NAME
+      description = POM_DESCRIPTION
+      url = POM_URL
+      licenses {
+        license {
+          name = POM_LICENCE_NAME
+          url = POM_LICENCE_URL
+        }
+      }
+      scm {
+        connection = POM_SCM_CONNECTION
+        developerConnection = POM_SCM_DEV_CONNECTION
+        url = POM_SCM_URL
+      }
     }
   }
 }


### PR DESCRIPTION
I did some digging and it appears that the Gradle Publishing Plugin use the Maven Publication plugin
(see https://plugins.gradle.org/docs/publish-plugin)

Using `publishing.publication`, I was able to set the license in the POM. I ran `./gradlew publishToMavenLocal` and the resulting POM file contained the license. 

POM file is located locally at:
`~/.m2/repository/com/jraska/module/graph/assertion/com.jraska.module.graph.assertion.gradle.plugin/2.7.2/com.jraska.module.graph.assertion.gradle.plugin-2.7.2.pom`

Resulting POM file:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.jraska.module.graph.assertion</groupId>
  <artifactId>com.jraska.module.graph.assertion.gradle.plugin</artifactId>
  <version>2.7.2</version>
  <packaging>pom</packaging>
  <name>Modules Graph Assert</name>
  <description>Gradle plugin to keep your modules graph healthy and lean.</description>
  <url>https://github.com/jraska/modules-graph-assert</url>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <scm>
    <connection>scm:git:git://github.com/jraska/modules-graph-assert.git</connection>
    <developerConnection>scm:git:ssh://github.com/jraska/modules-graph-assert.git</developerConnection>
    <url>https://github.com/jraska/modules-graph-assert</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>com.jraska.module.graph.assertion</groupId>
      <artifactId>plugin</artifactId>
      <version>2.7.2</version>
    </dependency>
  </dependencies>
</project>

```

I hope this solve https://github.com/jraska/modules-graph-assert/issues/288!