### PR TITLE
emit verification errors

### DIFF
--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleTreeHeightAssert.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/ModuleTreeHeightAssert.kt
@@ -1,7 +1,7 @@
 package com.jraska.module.graph.assertion
 
 import com.jraska.module.graph.DependencyGraph
-import org.gradle.api.GradleException
+import org.gradle.api.tasks.VerificationException
 import java.io.Serializable
 
 class ModuleTreeHeightAssert(
@@ -20,7 +20,7 @@ class ModuleTreeHeightAssert(
     val height = dependencyGraph.heightOf(moduleName)
     if (height > maxHeight) {
       val longestPath = dependencyGraph.longestPath(moduleName)
-      throw GradleException("Module $moduleName is allowed to have maximum height of $maxHeight, but has $height, problematic dependencies: ${longestPath.pathString()}")
+      throw VerificationException("Module $moduleName is allowed to have maximum height of $maxHeight, but has $height, problematic dependencies: ${longestPath.pathString()}")
     }
   }
 
@@ -28,7 +28,7 @@ class ModuleTreeHeightAssert(
     val height = dependencyGraph.height()
     if (height > maxHeight) {
       val longestPath = dependencyGraph.longestPath()
-      throw GradleException("Module Graph is allowed to have maximum height of $maxHeight, but has $height, problematic dependencies: ${longestPath.pathString()}")
+      throw VerificationException("Module Graph is allowed to have maximum height of $maxHeight, but has $height, problematic dependencies: ${longestPath.pathString()}")
     }
   }
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/OnlyAllowedAssert.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/OnlyAllowedAssert.kt
@@ -2,7 +2,7 @@ package com.jraska.module.graph.assertion
 
 import com.jraska.module.graph.DependencyGraph
 import com.jraska.module.graph.Parse
-import org.gradle.api.GradleException
+import org.gradle.api.tasks.VerificationException
 
 class OnlyAllowedAssert(
   private val allowedDependencies: Array<String>,
@@ -18,7 +18,7 @@ class OnlyAllowedAssert(
 
     if (disallowedDependencies.isNotEmpty()) {
       val allowedRules = allowedDependencies.joinToString(", ") { "'$it'" }
-      throw GradleException("$disallowedDependencies not allowed by any of [$allowedRules]")
+      throw VerificationException("$disallowedDependencies not allowed by any of [$allowedRules]")
     }
   }
 }

--- a/plugin/src/main/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssert.kt
+++ b/plugin/src/main/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssert.kt
@@ -3,7 +3,7 @@ package com.jraska.module.graph.assertion
 import com.jraska.module.graph.DependencyGraph
 import com.jraska.module.graph.Parse
 import com.jraska.module.graph.RegexpDependencyMatcher
-import org.gradle.api.GradleException
+import org.gradle.api.tasks.VerificationException
 
 class RestrictedDependenciesAssert(
   private val errorMatchers: Array<String>,
@@ -20,7 +20,7 @@ class RestrictedDependenciesAssert(
       }.filter { it.second.isNotEmpty() }
 
     if (failedDependencies.isNotEmpty()) {
-      throw GradleException(buildErrorMessage(failedDependencies))
+      throw VerificationException(buildErrorMessage(failedDependencies))
     }
   }
 

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/ModuleTreeHeightAssertTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/ModuleTreeHeightAssertTest.kt
@@ -1,7 +1,7 @@
 package com.jraska.module.graph.assertion
 
 import com.jraska.module.graph.DependencyGraph
-import org.gradle.api.GradleException
+import org.gradle.api.tasks.VerificationException
 import org.junit.Test
 
 class ModuleTreeHeightAssertTest {
@@ -12,7 +12,7 @@ class ModuleTreeHeightAssertTest {
     ModuleTreeHeightAssert("app", 3).assert(dependencyGraph)
   }
 
-  @Test(expected = GradleException::class)
+  @Test(expected = VerificationException::class)
   fun failsOnTooLargeHeight() {
     val dependencyGraph = testGraph()
 
@@ -26,7 +26,7 @@ class ModuleTreeHeightAssertTest {
     ModuleTreeHeightAssert(null, 3).assert(dependencyGraph)
   }
 
-  @Test(expected = GradleException::class)
+  @Test(expected = VerificationException::class)
   fun failsOnTooHighGraphHeight() {
     val dependencyGraph = testGraph()
 

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/OnlyAllowedAssertTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/OnlyAllowedAssertTest.kt
@@ -1,11 +1,11 @@
 package com.jraska.module.graph.assertion
 
 import com.jraska.module.graph.DependencyGraph
-import org.gradle.api.GradleException
+import org.gradle.api.tasks.VerificationException
 import org.junit.Test
 
 class OnlyAllowedAssertTest {
-  @Test(expected = GradleException::class)
+  @Test(expected = VerificationException::class)
   fun failsWithNoMatchingMatchers() {
     val dependencyGraph = testGraph()
 
@@ -33,7 +33,7 @@ class OnlyAllowedAssertTest {
     OnlyAllowedAssert(allowedDependencies).assert(dependencyGraph)
   }
 
-  @Test(expected = GradleException::class)
+  @Test(expected = VerificationException::class)
   fun failsWhenOneNotAllowed() {
     val dependencies = testGraph().dependencyPairs().toMutableList().apply { add("api" to "lib2") }
     val dependencyGraph = DependencyGraph.create(dependencies)

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssertTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/RestrictedDependenciesAssertTest.kt
@@ -1,7 +1,7 @@
 package com.jraska.module.graph.assertion
 
 import com.jraska.module.graph.DependencyGraph
-import org.gradle.api.GradleException
+import org.gradle.api.tasks.VerificationException
 import org.junit.Test
 
 class RestrictedDependenciesAssertTest {
@@ -12,14 +12,14 @@ class RestrictedDependenciesAssertTest {
     RestrictedDependenciesAssert(emptyArray()).assert(dependencyGraph)
   }
 
-  @Test(expected = GradleException::class)
+  @Test(expected = VerificationException::class)
   fun failsWhenFeatureCannotDependOnLib() {
     val dependencyGraph = testGraph()
 
     RestrictedDependenciesAssert(arrayOf("feature -X> lib2")).assert(dependencyGraph)
   }
 
-  @Test(expected = GradleException::class)
+  @Test(expected = VerificationException::class)
   fun failsWhenLibCannotDependOnAndroid() {
     val dependencyGraph = testGraph()
 
@@ -48,7 +48,7 @@ class RestrictedDependenciesAssertTest {
     ).assert(dependencyGraph)
   }
 
-  @Test(expected = GradleException::class)
+  @Test(expected = VerificationException::class)
   fun failsWithMatchersToAlias() {
     val dependencyGraph = DependencyGraph.create(
       "app" to "feature",


### PR DESCRIPTION
Fixes #290.

Also ensures that tests do not fail because of line separators (e.g. \r\n vs \n)
by using system default line separators for message comparison.