### PR TITLE
do not let tests fail because of line separator

### DIFF
--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectMultipleAppliedGradleTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectMultipleAppliedGradleTest.kt
@@ -67,12 +67,13 @@ class FullProjectMultipleAppliedGradleTest {
   fun printsBothCorrectStatistics() {
     val output =
       runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphStatistics").output
+    val ln = System.lineSeparator()
 
     println(output)
-    assert(output.contains("> Task :app:generateModulesGraphStatistics\n" +
-      "GraphStatistics(modulesCount=3, edgesCount=3, height=2, longestPath=':app -> :core -> :core-api')\n" +
-      "\n" +
-      "> Task :no-dependencies:generateModulesGraphStatistics\n" +
+    assert(output.contains("> Task :app:generateModulesGraphStatistics" + ln +
+      "GraphStatistics(modulesCount=3, edgesCount=3, height=2, longestPath=':app -> :core -> :core-api')" +
+      ln + ln +
+      "> Task :no-dependencies:generateModulesGraphStatistics" + ln +
       "GraphStatistics(modulesCount=1, edgesCount=0, height=0, longestPath=':no-dependencies')"))
   }
 

--- a/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectRootGradleTest.kt
+++ b/plugin/src/test/kotlin/com/jraska/module/graph/assertion/FullProjectRootGradleTest.kt
@@ -36,8 +36,9 @@ class FullProjectRootGradleTest {
 
     val output =
       runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphStatistics").output
+    val ln = System.lineSeparator()
 
-    assert(output.contains(("> Task :generateModulesGraphStatistics\n.*" +
+    assert(output.contains(("> Task :generateModulesGraphStatistics" + ln + ".*" +
       "GraphStatistics\\(modulesCount=2, edgesCount=1, height=1, longestPath=\'root.* -> :core\'\\)").toRegex()))
   }
 
@@ -71,10 +72,11 @@ class FullProjectRootGradleTest {
 
     val output =
       runGradleAssertModuleGraph(testProjectDir.root, "generateModulesGraphStatistics").output
+    val ln = System.lineSeparator()
 
-    assert(output.contains(("> Task :generateModulesGraphStatistics\n.*" +
-      "GraphStatistics\\(modulesCount=1, edgesCount=0, height=0, longestPath=\'root.*\'\\)\n\n" +
-      "> Task :app:generateModulesGraphStatistics\n+" +
+    assert(output.contains(("> Task :generateModulesGraphStatistics" + ln + ".*" +
+      "GraphStatistics\\(modulesCount=1, edgesCount=0, height=0, longestPath=\'root.*\'\\)" + ln + ln +
+      "> Task :app:generateModulesGraphStatistics" + ln + "+" +
       "GraphStatistics\\(modulesCount=1, edgesCount=0, height=0, longestPath=\':app\'\\)").toRegex()))
   }
 


### PR DESCRIPTION
Some tests were failing for me on Windows because the assertions relied on `\n` as line separator.