### PR TITLE
Migrate project to Version Catalogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,5 @@
-buildscript {
-  ext.kotlin_version = '2.2.20'
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
-  dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-  }
-}
-
-allprojects {
-  repositories {
-    google()
-    mavenCentral()
-  }
+plugins {
+  alias libs.plugins.kotlin.jvm apply false
 }
 
 tasks.register('clean', Delete) { Delete _ ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+kotlin = "2.2.20"
+junit = "4.13.2"
+publish = "1.3.1"
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+gradle-publish = { id = "com.gradle.plugin-publish", version.ref = "publish" }
+
+[libraries]
+junit = { module = "junit:junit", version.ref = "junit" }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,19 +1,13 @@
 plugins {
-  id "com.gradle.plugin-publish" version "1.3.1"
   id "java-gradle-plugin"
-}
-
-apply plugin: 'kotlin'
-
-repositories {
-  mavenCentral()
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.gradle.publish)
 }
 
 dependencies {
   implementation gradleApi()
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-  testImplementation 'junit:junit:4.13.2'
+  testImplementation libs.junit
 }
 
 compileKotlin {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,14 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+  }
+}
+
 include ':plugin'


### PR DESCRIPTION
Migrate the project to Gradle's [Version Catalogs](https://docs.gradle.org/current/userguide/version_catalogs.html).

This streamlines adding/updating dependencies and reduces `build.gradle` files size complexity.
