### PR TITLE
Add support for Gradle Lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,4 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3
       - name: Run Tests
-        run: ./gradlew check --stacktrace -X lintJvm
+        run: ./gradlew check --stacktrace -x lintJvm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,4 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3
       - name: Run Tests
-        run: ./gradlew check --stacktrace
+        run: ./gradlew check --stacktrace -X lintJvm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,10 @@
+name: Lint
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+      - name: Run Gradle Lint
+        run: ./gradlew lintJvm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,5 +6,13 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
+
       - name: Run Gradle Lint
         run: ./gradlew lintJvm
+
+      - name: Upload lint results
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-results
+          path: |
+            plugin/build/reports/lint-results.html

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   alias libs.plugins.kotlin.jvm apply false
+  alias libs.plugins.lint apply false
 }
 
 tasks.register('clean', Delete) { Delete _ ->

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,5 @@
-buildscript {
-  ext.kotlin_version = '2.2.20'
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
-  dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-  }
-}
-
-allprojects {
-  repositories {
-    google()
-    mavenCentral()
-  }
+plugins {
+  alias libs.plugins.kotlin.jvm apply false
 }
 
 tasks.register('clean', Delete) { Delete _ ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+kotlin = "2.2.20"
+junit = "4.13.2"
+publish = "1.3.1"
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+gradle-publish = { id = "com.gradle.plugin-publish", version.ref = "publish" }
+
+[libraries]
+junit = { module = "junit:junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,11 @@ junit = "4.13.2"
 publish = "1.3.1"
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+lint = { id = "com.android.lint", version = "8.12.3"}
 gradle-publish = { id = "com.gradle.plugin-publish", version.ref = "publish" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 
 [libraries]
+androidx-gradleLintChecks = 'androidx.lint:lint-gradle:1.0.0-alpha05'
+
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -2,10 +2,13 @@ plugins {
   id "java-gradle-plugin"
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.gradle.publish)
+  alias(libs.plugins.lint)
 }
 
 dependencies {
   implementation gradleApi()
+
+  lintChecks libs.androidx.gradleLintChecks
 
   testImplementation libs.junit
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,19 +1,13 @@
 plugins {
-  id "com.gradle.plugin-publish" version "1.3.1"
   id "java-gradle-plugin"
-}
-
-apply plugin: 'kotlin'
-
-repositories {
-  mavenCentral()
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.gradle.publish)
 }
 
 dependencies {
   implementation gradleApi()
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-  testImplementation 'junit:junit:4.13.2'
+  testImplementation libs.junit
 }
 
 compileKotlin {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,14 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+  }
+}
+
 include ':plugin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,12 +2,14 @@ pluginManagement {
   repositories {
     gradlePluginPortal()
     mavenCentral()
+    google()
   }
 }
 
 dependencyResolutionManagement {
   repositories {
     mavenCentral()
+    google()
   }
 }
 


### PR DESCRIPTION
Built on top of https://github.com/jraska/modules-graph-assert/pull/318 for easier libraries and plugins management.

This PR add support for running Gradle API related lint checks, which will help with supporting newer versions of Gradle and Gradle Project Isolation feature which lack of might be causing an issue with syncing, described here: https://github.com/jraska/modules-graph-assert/issues/315

From Gradle Lint [project description](https://developer.android.com/jetpack/androidx/releases/lint):
> An initial set of lint checks for Gradle Plugin authors to help them catch mistakes in their code. They are expected to be used on Gradle projects that apply java-gradle-plugin. It will catch uses of internal Gradle and Android Gradle Plugin APIs and eager task configuration.

For the migration phase, this PR explicitly disables lint tasks within regular CI checks and adds a new workflow that verifies if lint checks are passing.

#### On `com.android.lint` plugin
Android Lint plugin can be used within JVM projects and is not strictly related to Android.
It's being used in other popular Gradle plugins, e.g:
- [Apollo-Kotlin](https://github.com/apollographql/apollo-kotlin/blob/fd1ce3c12ea6c5997f295d7a857034120e864fbc/gradle/libraries.toml#L59)
- [Google KSP](https://github.com/google/ksp/blob/1c9670d55b50ee7508b055eb8e4af6bb9011293c/build.gradle.kts#L31)

Result from running Gradle Lint checks on this plugin so far:

<img width="912" height="875" alt="Screenshot 2025-10-23 at 12 59 31" src="https://github.com/user-attachments/assets/d23e14a8-d446-4013-bcc9-1c81a81bb8b2" />


